### PR TITLE
a few more colors for .js classes

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -93,8 +93,13 @@
   color: #555555;
 }
 
-.entity.name.class, .support.class.js {
+.entity.name.class {
   text-decoration: underline;
+}
+
+.support.class.js {
+  // text-decoration: underline;
+  color: #ff6100;
 }
 
 .entity.other.inherited-class {
@@ -135,7 +140,7 @@
 }
 
 .keyword.operator.js {
-  color: #FFFFFF;
+  color: #ff6100;
 }
 
 .keyword.control.js {


### PR DESCRIPTION
A few more colors for .js classes to be closer to the vim theme.  Operators are orange, as well as class names.
If you'd rather I publish as a separate theme instead of merging this, I could also do that.
